### PR TITLE
Add new `Heap#isEmpty()` predicate class method (#3)

### DIFF
--- a/src/heap.js
+++ b/src/heap.js
@@ -9,6 +9,10 @@ class Heap {
   get size() {
     return this._size;
   }
+
+  isEmpty() {
+    return !this._head && this._size === 0;
+  }
 }
 
 module.exports = Heap;

--- a/types/binoheap.d.ts
+++ b/types/binoheap.d.ts
@@ -20,6 +20,7 @@ declare namespace heap {
 
   export interface Instance<T> {
     readonly size: number;
+    isEmpty(): boolean;
   }
 }
 


### PR DESCRIPTION
## Description

The PR introduces the following new nullary predicate method: 

- `Heap#isEmpty()`

Determines whether the heap is empty or note, returning `true` or `false` as appropriate.

Also, the corresponding TypeScript ambient declarations are included in the PR.
