### PR TITLE
Add new `Heap#root()` class method (#3)

### DIFF
--- a/src/heap.js
+++ b/src/heap.js
@@ -43,6 +43,18 @@ class Heap {
   isEmpty() {
     return !this._head && this._size === 0;
   }
+
+  roots() {
+    const roots = [];
+    let {head: root} = this;
+
+    while (root) {
+      roots.push(root);
+      root = root.sibling;
+    }
+
+    return roots;
+  }
 }
 
 module.exports = Heap;

--- a/types/binoheap.d.ts
+++ b/types/binoheap.d.ts
@@ -26,6 +26,7 @@ declare namespace heap {
     readonly size: number;
     clear(): this;
     isEmpty(): boolean;
+    roots(): Array<Node<T>>;
   }
 }
 


### PR DESCRIPTION
## Description

The PR introduces the following new nullary method: 

- `Heap#roots()`

Traverses the root nodes of the binomial trees residing in the heap and stores of each traversed root node in an array. At the end of the traversal, the method returns the array which will contain all root node in ascending `degree` order.

Also, the corresponding TypeScript ambient declarations are included in the PR.
