### PR TITLE
Add new `Heap#merge(heap)` class method (#3)

### DIFF
--- a/src/heap.js
+++ b/src/heap.js
@@ -68,6 +68,43 @@ class Heap {
     return !this._head && this._size === 0;
   }
 
+  merge(heap) {
+    let head = this._mergeHeaps(this, heap);
+
+    if (head) {
+      let prev;
+      let curr = head;
+      let {sibling: next} = head;
+
+      while (next) {
+        const {sibling: postNext} = next;
+
+        if (curr.degree !== next.degree || (postNext && postNext.degree === curr.degree)) {
+          [prev, curr] = [curr, next];
+        } else if (this._compare(curr, next) < 0) {
+          curr.sibling = postNext;
+          this._addSubTree(curr, next);
+        } else {
+          if (prev) {
+            prev.sibling = next;
+          } else {
+            head = next;
+          }
+
+          this._addSubTree(next, curr);
+          curr = next;
+        }
+
+        next = postNext;
+      }
+
+      this._size += heap.size;
+      this._head = head;
+    }
+
+    return this;
+  }
+
   roots() {
     const roots = [];
     let {head: root} = this;

--- a/types/binoheap.d.ts
+++ b/types/binoheap.d.ts
@@ -26,6 +26,7 @@ declare namespace heap {
     readonly size: number;
     clear(): this;
     isEmpty(): boolean;
+    merge(heap: Instance<T>): Instance<T>;
     roots(): Array<Node<T>>;
   }
 }


### PR DESCRIPTION
## Description

The PR introduces the following new unary class method: 

- `Heap#merge(heap)`

Mutates the `Heap` instance by merging it with the given heap. Returns the resulting merged heap.

Also, the corresponding TypeScript ambient declarations & test cases are included in the PR.