### PR TITLE
Add new `Heap#insert(key, value)` class method (#3)

### DIFF
--- a/src/heap.js
+++ b/src/heap.js
@@ -64,6 +64,13 @@ class Heap {
     return this;
   }
 
+  insert(key, value) {
+    const heap = new Heap();
+    heap._head = new Node(key, value);
+    heap._size += 1;
+    return this.merge(heap);
+  }
+
   isEmpty() {
     return !this._head && this._size === 0;
   }

--- a/types/binoheap.d.ts
+++ b/types/binoheap.d.ts
@@ -25,8 +25,9 @@ declare namespace heap {
     readonly head: Node<T> | null;
     readonly size: number;
     clear(): this;
+    insert(key: number, value: T): this;
     isEmpty(): boolean;
-    merge(heap: Instance<T>): Instance<T>;
+    merge(heap: Instance<T>): this;
     roots(): Array<Node<T>>;
   }
 }


### PR DESCRIPTION
## Description

The PR introduces the following new binary class method: 

- `Heap#insert(key, value)`

Mutates the heap by inserting a new node. Returns the heap itself.

Also, the corresponding TypeScript ambient declarations & test cases are included in the PR.