### PR TITLE
Add new `Heap#findExtremum()` class method (#3)

### DIFF
--- a/src/heap.js
+++ b/src/heap.js
@@ -64,6 +64,26 @@ class Heap {
     return this;
   }
 
+  findExtremum() {
+    let {head: ext} = this;
+
+    if (!ext) {
+      return undefined;
+    }
+
+    let {sibling: next} = ext;
+
+    while (next) {
+      if (this._compare(ext, next) > 0) {
+        ext = next;
+      }
+
+      next = next.sibling;
+    }
+
+    return ext;
+  }
+
   insert(key, value) {
     const heap = new Heap();
     heap._head = new Node(key, value);

--- a/types/binoheap.d.ts
+++ b/types/binoheap.d.ts
@@ -25,6 +25,7 @@ declare namespace heap {
     readonly head: Node<T> | null;
     readonly size: number;
     clear(): this;
+    findExtremum(): Node<T> | undefined;
     insert(key: number, value: T): this;
     isEmpty(): boolean;
     merge(heap: Instance<T>): this;


### PR DESCRIPTION
## Description

The PR introduces the following new unary class method: 

- `Heap#findExtremum()`

Returns the node corresponding to the minimum `key` value, if the heap in min-ordered or the node corresponding to the maximum `key`, if the heap is max-ordered.

Also, the corresponding TypeScript ambient declarations & test cases are included in the PR.