### PR TITLE
Add new `Heap#extremumKey()` class method (#3)

### DIFF
--- a/src/heap.js
+++ b/src/heap.js
@@ -84,6 +84,16 @@ class Heap {
     return ext;
   }
 
+  extremumKey() {
+    const ext = this.extremum();
+
+    if (ext) {
+      return ext.key;
+    }
+
+    return undefined;
+  }
+
   insert(key, value) {
     const heap = new Heap();
     heap._head = new Node(key, value);

--- a/types/binoheap.d.ts
+++ b/types/binoheap.d.ts
@@ -26,6 +26,7 @@ declare namespace heap {
     readonly size: number;
     clear(): this;
     extremum(): Node<T> | undefined;
+    extremumKey(): number | undefined;
     insert(key: number, value: T): this;
     isEmpty(): boolean;
     merge(heap: Instance<T>): this;


### PR DESCRIPTION
## Description

The PR introduces the following new unary class method: 

- `Heap#extremumKey()`

Returns the minimum or the maximum `key` value in the heap, if the heap is min-ordered or max-ordered respectively.

Also, the corresponding TypeScript ambient declarations & test cases are included in the PR.