### PR TITLE
Add new `Heap#removeExtremum()` class method (#3)

### DIFF
--- a/src/heap.js
+++ b/src/heap.js
@@ -178,6 +178,36 @@ class Heap {
     return this;
   }
 
+  removeExtremum() {
+    let {head: ext} = this;
+
+    if (!ext) {
+      return undefined;
+    }
+
+    let extPrev;
+    let curr = ext;
+    let {sibling: next} = ext;
+
+    while (next) {
+      if (this._compare(ext, next) > 0) {
+        ext = next;
+        extPrev = curr;
+      }
+
+      curr = next;
+      next = next.sibling;
+    }
+
+    this._removeRoot(extPrev, ext);
+
+    const heap = new Heap();
+    heap._head = this._reverseRoots(ext.child);
+
+    this.merge(heap);
+    return ext;
+  }
+
   roots() {
     const roots = [];
     let {head: root} = this;

--- a/types/binoheap.d.ts
+++ b/types/binoheap.d.ts
@@ -31,6 +31,7 @@ declare namespace heap {
     insert(key: number, value: T): this;
     isEmpty(): boolean;
     merge(heap: Instance<T>): this;
+    removeExtremum(): Node<T> | undefined;
     roots(): Array<Node<T>>;
   }
 }


### PR DESCRIPTION
## Description

The PR introduces the following new nullary class method: 

- `Heap#removeExtremum()`

Removes from the heap the node corresponding to the minimum `key` value, if the heap is min-ordered or the node corresponding to the maximum `key` if the heap is max-ordered. The removed node is returned by the method if the heap is not empty. If the heap is empty then undefined` is returned instead.

Also, the corresponding TypeScript ambient declarations & test cases are included in the PR.