### PR TITLE
Add new `Node#siblings()` class method (#3)

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -50,6 +50,18 @@ class Node {
     this._sibling = node;
   }
 
+  siblings() {
+    const siblings = [];
+    let {sibling: node} = this;
+
+    while (node) {
+      siblings.push(node);
+      node = node.sibling;
+    }
+
+    return siblings;
+  }
+
   toPair() {
     return [this._key, this._value];
   }

--- a/types/binoheap.d.ts
+++ b/types/binoheap.d.ts
@@ -10,6 +10,7 @@ declare namespace node {
     parent: Instance<T> | null;
     child: Instance<T> | null;
     sibling: Instance<T> | null;
+    siblings(): Array<Instance<T>>;
     toPair(): [number, T];
   }
 }


### PR DESCRIPTION
## Description

The PR introduces the following new nullary class method: 

- `Node#siblings()`

Traverses all sibling nodes of the `Node` instance and stores them in an array. The array is returned at the end of the traversal.

Also, the corresponding TypeScript ambient declarations & test cases are included in the PR.