### PR TITLE
Add new `Heap#includes(key)` class method (#3)

### DIFF
--- a/src/heap.js
+++ b/src/heap.js
@@ -134,6 +134,46 @@ class Heap {
     return this.roots().length;
   }
 
+  includes(key) {
+    let {head: current} = this;
+
+    if (current) {
+      const queue = [];
+
+      while (current || queue.length > 0) {
+        const siblings = current.siblings();
+        let nodes = siblings.length + 1;
+
+        queue.push(...siblings);
+
+        while (nodes > 0) {
+          console.log({
+            key: current.key,
+            child: current.child ? current.child.key : null,
+            sibling: current.sibling ? current.sibling.key : null,
+            nodes,
+            queue: queue.length
+          });
+
+          if (current.key === key) {
+            return true;
+          }
+
+          const {child} = current;
+
+          if (child) {
+            queue.push(child);
+          }
+
+          nodes -= 1;
+          current = queue.shift();
+        }
+      }
+    }
+
+    return false;
+  }
+
   insert(key, value) {
     const heap = new Heap();
     heap._head = new Node(key, value);

--- a/types/binoheap.d.ts
+++ b/types/binoheap.d.ts
@@ -31,6 +31,7 @@ declare namespace heap {
     extremumKey(): number | undefined;
     extremumValue(): T | undefined;
     heapTrees(): number;
+    includes(key: number): boolean;
     insert(key: number, value: T): this;
     isEmpty(): boolean;
     merge(heap: Instance<T>): this;


### PR DESCRIPTION
## Description

The PR introduces the following new unary predicate class method: 

- `Node#includes(key)`

Traverses the nodes in the binomial heap level by level, left to right & top to bottom, and determines whether the heap includes a node with a certain `key`, returning `true` or `false` as appropriate.

Also, the corresponding TypeScript ambient declarations & test cases are included in the PR.