### PR TITLE
Add new `Heap#search(key)` class method (#3)

### DIFF
--- a/src/heap.js
+++ b/src/heap.js
@@ -255,6 +255,38 @@ class Heap {
 
     return roots;
   }
+
+  search(key) {
+    let {head: current} = this;
+
+    if (current) {
+      const queue = [];
+
+      while (current || queue.length > 0) {
+        const siblings = current.siblings();
+        let nodes = siblings.length + 1;
+
+        queue.push(...siblings);
+
+        while (nodes > 0) {
+          if (current.key === key) {
+            return current;
+          }
+
+          const {child} = current;
+
+          if (child) {
+            queue.push(child);
+          }
+
+          nodes -= 1;
+          current = queue.shift();
+        }
+      }
+    }
+
+    return undefined;
+  }
 }
 
 module.exports = Heap;

--- a/types/binoheap.d.ts
+++ b/types/binoheap.d.ts
@@ -37,6 +37,7 @@ declare namespace heap {
     merge(heap: Instance<T>): this;
     removeExtremum(): Node<T> | undefined;
     roots(): Array<Node<T>>;
+    search(key: number): Node<T> | undefined;
   }
 }
 


### PR DESCRIPTION
## Description

The PR introduces the following new unary class method: 

- `Node#search(key)`

Traverses the nodes in the binomial heap level by level, left to right & top to bottom, and determines whether the heap includes a node with a certain `key`, returning the node itself or `false` as appropriate.

Also, the corresponding TypeScript ambient declarations & test cases are included in the PR.