### PR TITLE
Add new `Heap#updateKey(key, newKey)` class method. Fixes #3.

### DIFF
--- a/src/heap.js
+++ b/src/heap.js
@@ -276,6 +276,17 @@ class Heap {
 
     return undefined;
   }
+
+  updateKey(key, newKey) {
+    const target = this.search(key);
+
+    if (target && this._compare({key: newKey}, target) < 0) {
+      target._key = newKey;
+      this._bubbleUp(target);
+    }
+
+    return this;
+  }
 }
 
 module.exports = Heap;

--- a/types/binoheap.d.ts
+++ b/types/binoheap.d.ts
@@ -38,6 +38,7 @@ declare namespace heap {
     removeExtremum(): Node<T> | undefined;
     roots(): Array<Node<T>>;
     search(key: number): Node<T> | undefined;
+    updateKey(key: number, newKey: number): this;
   }
 }
 


### PR DESCRIPTION
## Description

The PR introduces the following new binary class method: 

- `Node#updateKey(key, newKey)`

Traverses the nodes in the binomial heap level by level, left to right & top to bottom, and determines whether the heap includes a node with the given `key` value. If the node is found then, its `key` value is mutated by replacing it with the new `newKey` one. Returns the heap itself.

The method can be used to only decrease or increase the key value of targeted nodes if the binomial heap is either min or max ordered. 

Also, the corresponding TypeScript ambient declarations & test cases are included in the PR.