### PR TITLE
Docs: Add API documentation for `Node` class methods

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -708,6 +708,199 @@ maxHeap.head.child;
 //=> Node { key: 20, value: 'B', degree: 0, parent: [Node], child: null, sibling: null }
 ```
 
+Available, along with the `Heap` exposed class, is the `Node` class, mainly useful for testing purposes, since it can be utilized to compare heap nodes. The class has a binary constructor method, with a `key` and a `value` parameter, corresponding to the key and the value stored in the created instance, respectively.
+
+#### node.`key`
+
+- Return Type: `Number`
+
+The `key` corresponding to the node instance.
+
+```js
+const {Node} = require('binoheap');
+
+const node = new Node(10, 'A');
+// => Node { key: 10, value: 'A', degree: 0, parent: null, child: null, sibling: null }
+node.key;
+//=> 10
+```
+
+#### node.`value`
+
+- Return Type: `Any`
+
+The value that the node contains.
+
+```js
+const {Node} = require('binoheap');
+
+const node = new Node(10, 'A');
+//=> Node { key: 10, value: 'A', degree: 0, parent: null, child: null, sibling: null }
+node.value;
+//=> 'A'
+node.value = 'B'
+//=> Node { key: 10, value: 'B', degree: 0, parent: null, child: null, sibling: null }
+node.value;
+//=> 'B'
+```
+
+#### node.`degree`
+
+- Return Type: `Number`
+
+Degree of the node.
+
+```js
+const {Heap} = require('binoheap');
+
+const heap = new Heap();
+//=> Heap {
+// size: 0,
+// head: null }
+heap.insert(10, 'A').head;
+//=> Node { key: 10, value: 'A', degree: 0, parent: null, child: null, sibling: null } }
+heap.head.degree;
+//=> 1
+heap.insert(20, 'B').head;
+//=> Node { key: 10, value: 'A', degree: 1, parent: null, child: [Node], sibling: null } }
+heap.head.degree;
+//=> 1
+```
+
+#### node.`parent`
+
+- Return Type: `Node | null`
+
+The parent node of the node instance.
+
+```js
+const {Node} = require('binoheap');
+
+const node1 = new Node(10, 'A');
+// => Node { key: 10, value: 'A', degree: 0, parent: null, child: null, sibling: null }
+node1.parent;
+//=> null
+const node2 = new Node(20, 'B');
+// => Node { key: 20, value: 'B', degree: 0, parent: null, child: null, sibling: null }
+node1.parent = node2;
+// => Node { key: 10, value: 'A', degree: 0, parent: [Node], child: null, sibling: null }
+```
+
+#### node.`child`
+
+- Return Type: `Node | null`
+
+The child node of the node instance.
+
+```js
+const {Node} = require('binoheap');
+
+const node1 = new Node(10, 'A');
+// => Node { key: 10, value: 'A', degree: 0, parent: null, child: null, sibling: null }
+node1.child;
+//=> null
+const node2 = new Node(20, 'B');
+// => Node { key: 20, value: 'B', degree: 0, parent: null, child: null, sibling: null }
+node1.child = node2;
+// => Node { key: 10, value: 'A', degree: 0, parent: null, child: [Node], sibling: null }
+```
+
+#### node.`child`
+
+- Return Type: `Node | null`
+
+The sibling node of the node instance.
+
+```js
+const {Node} = require('binoheap');
+
+const node1 = new Node(10, 'A');
+// => Node { key: 10, value: 'A', degree: 0, parent: null, child: null, sibling: null }
+node1.sibling;
+//=> null
+const node2 = new Node(20, 'B');
+// => Node { key: 20, value: 'B', degree: 0, parent: null, child: null, sibling: null }
+node1.sibling = node2;
+// => Node { key: 10, value: 'A', degree: 0, parent: null, child: null, sibling: [Node] }
+```
+
+#### node.`siblings()`
+
+- Return Type: `Array<Node>`
+
+Traverses all sibling nodes of the `Node` instance and stores them in an array. The array is returned at the end of the traversal.
+
+```js
+const {Heap} = require('binoheap');
+
+const heap = new Heap();
+//=> Heap {
+// size: 0,
+// head: null } }
+heap
+  .insert(10, 'A')
+  .insert(20, 'B')
+  .insert(30, 'C')
+  .insert(40, 'D')
+  .insert(50, 'E')
+  .insert(60, 'F')
+  .insert(70, 'G');
+//=> Heap {
+// size: 7,
+// head: Node { key: 70, value: 'G', degree: 0, parent: null, child: [Node], sibling: null } }
+heap.head.siblings();
+//=> [
+// Node { key: 50, value: 'E', degree: 1, parent: null, child: [Node], sibling: [Node] },
+// Node { key: 10, value: 'A', degree: 2, parent: null, child: [Node], sibling: null }
+// ]
+```
+
+#### node.`descendants()`
+
+- Return Type: `Array<Node>`
+
+Traverses all the descendant nodes of the `Node` instance, through the `Node#child` pointer, and stores each one of them in an array. The array is returned at the end of the traversal.
+
+```js
+const {Heap} = require('binoheap');
+
+const heap = new Heap();
+//=> Heap {
+// size: 0,
+// head: null } }
+heap
+  .insert(10, 'A')
+  .insert(20, 'B')
+  .insert(30, 'C')
+  .insert(40, 'D');
+//=> Heap {
+// size: 7,
+// head: Node { key: 10, value: 'A', degree: 2, parent: null, child: [Node], sibling: null } }
+heap.head.descendants();
+//=> [
+// Node { key: 30, value: 'C', degree: 1, parent: [Node], child: [Node], sibling: [Node] },
+// Node { key: 40, value: 'D', degree: 0, parent: [Node], child: , sibling: null }
+// ]
+```
+
+#### node.`toPair()`
+
+- Return Type: `[Number, Any]`
+
+Returns an ordered-pair/2-tuple, where the first element is a number corresponding to the `key` of the node, and the last one is a value, that can be of any type, corresponding to the `value` stored in the node.
+
+```js
+const {Heap, Node} = require('binoheap');
+
+const heap = new Heap();
+const node = new Node(5, 'B');
+
+node.toPair();
+//=> [5, 'B']
+heap.insert(10, 'A').head.toPair();
+//=> [10, 'A']
+```
+
 ## Development
 
 For more info on how to contribute to the project, please read the [contributing guidelines](https://github.com/klaussinani/binoheap/blob/master/contributing.md).


### PR DESCRIPTION
## Description

The PR updates the readme `API` section by adding the needed documentation for the methods & property accessors/mutators of the `Node` class, as described on thread/issue (#3). 