### PR TITLE
Replace `any` default type for generics with `unknown`

### DIFF
--- a/types/binoheap.d.ts
+++ b/types/binoheap.d.ts
@@ -1,6 +1,6 @@
 declare namespace node {
   export interface Constructor {
-    new <T = any>(key: number, value: T): Instance<T>;
+    new <T = unknown>(key: number, value: T): Instance<T>;
   }
 
   export interface Instance<T> {
@@ -20,7 +20,7 @@ declare namespace heap {
   interface Node<T> extends node.Instance<T> {}
 
   export interface Constructor {
-    new <T = any>(comparatorFn?: (x: Node<T>, y: Node<T>) => number): Instance<T>;
+    new <T = unknown>(comparatorFn?: (x: Node<T>, y: Node<T>) => number): Instance<T>;
   }
 
   export interface Instance<T> {
@@ -43,8 +43,8 @@ declare namespace heap {
 }
 
 declare namespace binoheap {
-  export interface Heap<T = any> extends heap.Instance<T> {}
-  export interface Node<T = any> extends node.Instance<T> {}
+  export interface Heap<T = unknown> extends heap.Instance<T> {}
+  export interface Node<T = unknown> extends node.Instance<T> {}
 }
 
 declare const binoheap: {


### PR DESCRIPTION
## Description
The PR replaces the any type used as the default type for the generic type parameters with the more type-safe [unknown](https://devblogs.microsoft.com/typescript/announcing-typescript-3-0-rc-2/#the-unknown-type) type.